### PR TITLE
adjusted python path and fixed elbows bent command spec

### DIFF
--- a/naorecorder.sh
+++ b/naorecorder.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
-export PYTHONPATH=${PYTHONPATH}:src/main/python
+export PYTHONPATH=src/main/python:${PYTHONPATH}
 python src/main/python/recorder/main.py

--- a/src/main/python/translators/fluentnao/core.py
+++ b/src/main/python/translators/fluentnao/core.py
@@ -258,7 +258,7 @@ COMMANDS = [
                         set(['LElbowRoll', 'RElbowRoll']),
                         [Transform(linear, 'LElbowRoll', 'lroll', [1, -0.5]),
                          Transform(linear, 'RElbowRoll', 'rroll', [1, 0.5])],
-                        [Constraint(less_than, [43, 'LElbowRoll']),
+                        [Constraint(greater_than, [-43, 'LElbowRoll']),
                           Constraint(less_than, [43, 'RElbowRoll']),
                          Constraint(max_difference, [10, 'lroll', 'rroll'])],
                         ['rroll']


### PR DESCRIPTION
Adjusted python path to ensure we override any other reference to FluentNao.  Also fixed elbows bent command spec.
